### PR TITLE
Commit 0dc51d0 from r3d

### DIFF
--- a/src/collision/TriangleMesh.cpp
+++ b/src/collision/TriangleMesh.cpp
@@ -217,7 +217,7 @@ bool TriangleMesh::copyData(const TriangleVertexArray& triangleVertexArray, std:
 void TriangleMesh::removeUnusedVertices(Array<bool>& areUsedVertices) {
 
     // For each vertex of the user mesh
-    for (uint32 i=mVertices.size() - 1; i > 0; i--) {
+    for (int64 i=mVertices.size() - 1; i >= 0; i--) {
 
         // If the vertex is not used
         if (!areUsedVertices[i]) {


### PR DESCRIPTION
Fix issue with wrong index condition in TriangleMesh::removeUnusedVertices() method

I figured we could add this fix from https://github.com/DanielChappuis/reactphysics3d/commit/0dc51d0b83289f4fd78c316f143b1cb74dfc7b86

hope the change to int64 from uint32 won't be a problem.